### PR TITLE
feat(catalog): improved card alignment and UI; debounce search, categories, skeleton loaders; use mock data

### DIFF
--- a/frontend/src/components/ServiceCard.tsx
+++ b/frontend/src/components/ServiceCard.tsx
@@ -1,16 +1,18 @@
 import React from 'react';
 
 interface ServiceCardProps {
-  name: string;
+  name: string;                 // display name (can be title-cased by caller)
   description: string;
   stars: number;
   pulls: number;
   latestTag: string;
   official: boolean;
   verified: boolean;
-  logo?: string;
+  imageUrl?: string;            // new: image URL from mockdata.ts (future)
+  logo?: string;                // backward-compat alias
   added?: boolean;
   onAdd: () => void;
+  onRemove?: () => void;        // new: remove handler
 }
 
 function formatNum(n: number) {
@@ -28,23 +30,29 @@ export default function ServiceCard({
   latestTag,
   official,
   verified,
+  imageUrl,
   logo,
   added = false,
   onAdd,
+  onRemove,
 }: ServiceCardProps) {
+  const imgSrc =
+    imageUrl ??
+    logo ??
+    'https://static-00.iconduck.com/assets.00/docker-icon-512x512-yx9lqv3o.png';
+
   return (
     <article className="group h-full rounded-xl border border-gray-700 bg-gray-800/80 hover:bg-gray-800 transition-colors shadow-sm p-4 flex flex-col">
       <div className="flex items-start gap-3">
         <div className="h-10 w-10 rounded-md bg-gray-700 flex items-center justify-center overflow-hidden shrink-0">
-          {logo ? (
-            <img src={logo} alt={name} className="h-10 w-10 object-contain" />
-          ) : (
-            <span className="text-gray-300 text-sm">IMG</span>
-          )}
+          <img src={imgSrc} alt={name} className="h-10 w-10 object-contain" />
         </div>
         <div className="min-w-0 flex-1">
           <div className="flex items-start gap-2">
-            <h3 className="text-base md:text-lg font-semibold text-white truncate">{name}</h3>
+            {/* Ensure full visibility, no truncation; allow wrapping */}
+            <h3 className="text-base md:text-lg font-semibold text-white break-words leading-snug">
+              {name}
+            </h3>
             <div className="ml-auto flex items-center gap-1 shrink-0">
               {official && (
                 <span className="text-[10px] uppercase tracking-wide bg-blue-600/20 text-blue-300 border border-blue-600/40 px-1.5 py-0.5 rounded">
@@ -63,7 +71,7 @@ export default function ServiceCard({
               )}
             </div>
           </div>
-          <p className="mt-1 text-sm text-gray-300 min-h-[48px] overflow-hidden">
+          <p className="mt-1 text-sm text-gray-300">
             {description}
           </p>
         </div>
@@ -78,20 +86,31 @@ export default function ServiceCard({
           <span aria-hidden className="text-blue-400">⬇</span>
           <span>{formatNum(pulls)}</span>
         </div>
-        <div className="truncate text-xs text-gray-400 ml-auto">docker.io/{name}:{latestTag}</div>
+        {latestTag && (
+          <div className="truncate text-xs text-gray-400 ml-auto">
+            :{latestTag}
+          </div>
+        )}
       </div>
 
       <div className="mt-auto pt-4">
-        <button
-          onClick={onAdd}
-          disabled={added}
-          className={`w-full rounded-lg px-3 py-2 text-sm font-medium transition
-            ${added ? 'bg-gray-700 text-gray-300 cursor-default' : 'bg-blue-600 hover:bg-blue-500 text-white'}
-          `}
-          aria-label={added ? 'Added to Composer' : 'Add to Composer'}
-        >
-          {added ? 'Added' : 'Add to Composer'}
-        </button>
+        {added ? (
+          <button
+            onClick={onRemove}
+            className="w-full rounded-lg px-3 py-2 text-sm font-medium transition bg-red-600 hover:bg-red-500 text-white"
+            aria-label="Remove from Composer"
+          >
+            Remove from Composer
+          </button>
+        ) : (
+          <button
+            onClick={onAdd}
+            className="w-full rounded-lg px-3 py-2 text-sm font-medium transition bg-blue-600 hover:bg-blue-500 text-white"
+            aria-label="Add to Composer"
+          >
+            Add to Composer
+          </button>
+        )}
       </div>
     </article>
   );

--- a/frontend/src/components/ServiceCard.tsx
+++ b/frontend/src/components/ServiceCard.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+
+interface ServiceCardProps {
+  name: string;
+  description: string;
+  stars: number;
+  pulls: number;
+  latestTag: string;
+  official: boolean;
+  verified: boolean;
+  logo?: string;
+  added?: boolean;
+  onAdd: () => void;
+}
+
+function formatNum(n: number) {
+  if (n >= 1_000_000_000) return (n / 1_000_000_000).toFixed(1) + 'B';
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+  return String(n);
+}
+
+export default function ServiceCard({
+  name,
+  description,
+  stars,
+  pulls,
+  latestTag,
+  official,
+  verified,
+  logo,
+  added = false,
+  onAdd,
+}: ServiceCardProps) {
+  return (
+    <article className="group h-full rounded-xl border border-gray-700 bg-gray-800/80 hover:bg-gray-800 transition-colors shadow-sm p-4 flex flex-col">
+      <div className="flex items-start gap-3">
+        <div className="h-10 w-10 rounded-md bg-gray-700 flex items-center justify-center overflow-hidden shrink-0">
+          {logo ? (
+            <img src={logo} alt={name} className="h-10 w-10 object-contain" />
+          ) : (
+            <span className="text-gray-300 text-sm">IMG</span>
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start gap-2">
+            <h3 className="text-base md:text-lg font-semibold text-white truncate">{name}</h3>
+            <div className="ml-auto flex items-center gap-1 shrink-0">
+              {official && (
+                <span className="text-[10px] uppercase tracking-wide bg-blue-600/20 text-blue-300 border border-blue-600/40 px-1.5 py-0.5 rounded">
+                  Official
+                </span>
+              )}
+              {verified && (
+                <span className="text-[10px] uppercase tracking-wide bg-emerald-600/20 text-emerald-300 border border-emerald-600/40 px-1.5 py-0.5 rounded">
+                  Verified
+                </span>
+              )}
+              {latestTag && (
+                <span className="text-xs text-gray-300 bg-gray-700 rounded px-2 py-0.5">
+                  {latestTag}
+                </span>
+              )}
+            </div>
+          </div>
+          <p className="mt-1 text-sm text-gray-300 min-h-[48px] overflow-hidden">
+            {description}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center gap-4 text-sm text-gray-300">
+        <div className="flex items-center gap-1">
+          <span aria-hidden className="text-yellow-400">★</span>
+          <span>{formatNum(stars)}</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <span aria-hidden className="text-blue-400">⬇</span>
+          <span>{formatNum(pulls)}</span>
+        </div>
+        <div className="truncate text-xs text-gray-400 ml-auto">docker.io/{name}:{latestTag}</div>
+      </div>
+
+      <div className="mt-auto pt-4">
+        <button
+          onClick={onAdd}
+          disabled={added}
+          className={`w-full rounded-lg px-3 py-2 text-sm font-medium transition
+            ${added ? 'bg-gray-700 text-gray-300 cursor-default' : 'bg-blue-600 hover:bg-blue-500 text-white'}
+          `}
+          aria-label={added ? 'Added to Composer' : 'Add to Composer'}
+        >
+          {added ? 'Added' : 'Add to Composer'}
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/ServiceCard.tsx
+++ b/frontend/src/components/ServiceCard.tsx
@@ -86,11 +86,7 @@ export default function ServiceCard({
           <span aria-hidden className="text-blue-400">⬇</span>
           <span>{formatNum(pulls)}</span>
         </div>
-        {latestTag && (
-          <div className="truncate text-xs text-gray-400 ml-auto">
-            :{latestTag}
-          </div>
-        )}
+        
       </div>
 
       <div className="mt-auto pt-4">

--- a/frontend/src/components/SkeletonCard.tsx
+++ b/frontend/src/components/SkeletonCard.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function SkeletonCard() {
+  return (
+    <div className="h-full rounded-xl border border-gray-700 bg-gray-800 p-4 animate-pulse flex flex-col">
+      <div className="flex items-start gap-3">
+        <div className="h-10 w-10 rounded-md bg-gray-700" />
+        <div className="flex-1 space-y-2">
+          <div className="h-4 w-1/3 bg-gray-700 rounded" />
+          <div className="h-3 w-3/4 bg-gray-700 rounded" />
+        </div>
+      </div>
+      <div className="mt-4 flex gap-3">
+        <div className="h-3 w-16 bg-gray-700 rounded" />
+        <div className="h-3 w-16 bg-gray-700 rounded" />
+        <div className="h-3 w-24 bg-gray-700 rounded" />
+      </div>
+      <div className="mt-auto pt-4 h-9 w-full bg-gray-700 rounded" />
+    </div>
+  );
+}

--- a/frontend/src/hooks/useDebouncedValue.ts
+++ b/frontend/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from 'react';
+
+export function useDebouncedValue<T>(value: T, delay = 300) {
+  const [debounced, setDebounced] = useState<T>(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+  return debounced;
+}

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -27,6 +27,14 @@ function toTitleCase(s: string) {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+// Prefix 'v' for version-like tags (e.g., 1.25.3 -> v1.25.3). Leave non-version tags (e.g., latest) unchanged.
+function formatVersionTag(tag?: string) {
+  if (!tag) return '';
+  if (/^v/i.test(tag)) return tag;
+  if (/^\d/.test(tag)) return `v${tag}`;
+  return tag;
+}
+
 const Catalog = () => {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<string>('All');
@@ -109,34 +117,33 @@ const Catalog = () => {
         <p className="text-gray-300 mt-1">{headerText}</p>
       </header>
 
-      <div className="mb-6 grid grid-cols-1 gap-3 md:grid-cols-3">
-        <div className="md:col-span-2">
-          <div className="relative">
-            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="opacity-80">
-                <path d="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z" stroke="currentColor" strokeWidth="2"/>
-                <path d="M21 21l-4.3-4.3" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
-              </svg>
-            </span>
-            <input
-              type="text"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search images (e.g. nginx, postgres, redis)"
-              className="w-full rounded-xl bg-gray-800 border border-gray-700 text-gray-100 placeholder-gray-400 pl-10 pr-9 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
-              aria-label="Search Docker images"
-            />
-            {query && (
-              <button
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-white"
-                onClick={() => setQuery('')}
-                aria-label="Clear search"
-                title="Clear"
-              >
-                ×
-              </button>
-            )}
-          </div>
+      {/* Search on top, categories below for better UI */}
+      <div className="mb-6 space-y-3">
+        <div className="relative">
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="opacity-80">
+              <path d="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z" stroke="currentColor" strokeWidth="2"/>
+              <path d="M21 21l-4.3-4.3" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+            </svg>
+          </span>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search images (e.g. nginx, postgres, redis)"
+            className="w-full rounded-xl bg-gray-800 border border-gray-700 text-gray-100 placeholder-gray-400 pl-10 pr-9 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            aria-label="Search Docker images"
+          />
+          {query && (
+            <button
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-white"
+              onClick={() => setQuery('')}
+              aria-label="Clear search"
+              title="Clear"
+            >
+              ×
+            </button>
+          )}
         </div>
 
         <div className="overflow-x-auto">
@@ -205,7 +212,7 @@ const Catalog = () => {
                         <div className="ml-auto flex items-center gap-1 shrink-0">
                           {img.latestTag && (
                             <span className="text-xs text-gray-300 bg-gray-700 rounded px-2 py-0.5">
-                              {img.latestTag}
+                              {formatVersionTag(img.latestTag)}
                             </span>
                           )}
                         </div>

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -190,7 +190,7 @@ const Catalog = () => {
               const key = `${img.name}:${img.latestTag}`;
               const added = !!addedMap[key];
               const displayName = toTitleCase(img.name);
-              const imgUrl = (img as any).logo || (img as any).imageUrl || placeholderLogo;
+              const imgUrl = img.logo || img.imageUrl || placeholderLogo;
 
               return (
                 <article

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { mockDockerImages, mockCategories, searchImages, type DockerImage } from '../mockdata';
-import ServiceCard from '../components/ServiceCard';
-import SkeletonCard from '../components/SkeletonCard';
+import { mockDockerImages, mockCategories, type DockerImage } from '../mockdata';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
+import '../styles/catalogue.css';
 
 type SelectedService = { name: string; tag: string };
 const STORAGE_KEY = 'composer:selectedServices';
@@ -17,6 +16,15 @@ function loadSelections(): SelectedService[] {
 
 function saveSelections(items: SelectedService[]) {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+}
+
+function toTitleCase(s: string) {
+  return s
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
 const Catalog = () => {
@@ -34,27 +42,20 @@ const Catalog = () => {
     setAddedMap(map);
   }, []);
 
-  // compute filtered results from mock data
+  // compute filtered results from mock data (name/description/tags + category)
   const filtered: DockerImage[] = useMemo(() => {
     let list = mockDockerImages.slice();
     if (category !== 'All') {
       list = list.filter((i) => i.category === category);
     }
-    if (debouncedQuery.trim()) {
-      const lower = debouncedQuery.toLowerCase();
-      // use helper search and then apply category
-      const searched = searchImages(debouncedQuery);
-      list = searched.filter((i) => (category === 'All' ? true : i.category === category));
-      // ensure deterministic order if helper expands later
-      list = list.filter(Boolean);
-      // Fallback simple filter to include more matches
-      if (list.length === 0) {
-        list = mockDockerImages.filter(
-          (i) =>
-            (category === 'All' ? true : i.category === category) &&
-            (i.name.toLowerCase().includes(lower) || i.description.toLowerCase().includes(lower))
-        );
-      }
+    const q = debouncedQuery.trim().toLowerCase();
+    if (q) {
+      list = list.filter((i) => {
+        const inName = i.name.toLowerCase().includes(q);
+        const inDesc = i.description.toLowerCase().includes(q);
+        const inTags = Array.isArray(i.tags) && i.tags.some((t) => t.toLowerCase().includes(q));
+        return inName || inDesc || inTags;
+      });
     }
     // sort by popularity (stars desc, pulls desc)
     list.sort((a, b) => b.stars - a.stars || b.pulls - a.pulls || a.name.localeCompare(b.name));
@@ -64,7 +65,7 @@ const Catalog = () => {
   // simulate loading state on every query/category change for skeleton UX
   useEffect(() => {
     setLoading(true);
-    const t = setTimeout(() => setLoading(false), 300);
+    const t = setTimeout(() => setLoading(false), 250);
     return () => clearTimeout(t);
   }, [debouncedQuery, category]);
 
@@ -76,32 +77,45 @@ const Catalog = () => {
       const next = [...existing, entry];
       saveSelections(next);
       setAddedMap((prev) => ({ ...prev, [key]: true }));
-      // Notify other parts of the app (Composer) if listening
       window.dispatchEvent(new CustomEvent('composer:addService', { detail: entry }));
     }
   };
 
+  const onRemove = (img: DockerImage) => {
+    const key = `${img.name}:${img.latestTag}`;
+    const existing = loadSelections().filter((e) => !(e.name === img.name && e.tag === img.latestTag));
+    saveSelections(existing);
+    setAddedMap((prev) => {
+      const copy = { ...prev };
+      delete copy[key];
+      return copy;
+    });
+    window.dispatchEvent(new CustomEvent('composer:removeService', { detail: { name: img.name, tag: img.latestTag } }));
+  };
+
+  const headerText = loading
+    ? 'Searching Docker images...'
+    : debouncedQuery
+    ? `Results for "${debouncedQuery}"`
+    : 'Browse available services and add them to your compose.';
+
+  const placeholderLogo =
+    'https://static-00.iconduck.com/assets.00/docker-icon-512x512-yx9lqv3o.png';
+
   return (
-    <div className="max-w-7xl mx-auto px-4 py-8">
+    <div className="catalogue-page max-w-7xl mx-auto px-4 py-8">
       <header className="mb-6">
         <h1 className="text-3xl font-bold text-white">Catalog</h1>
-        <p className="text-gray-300 mt-1">
-          {loading
-            ? 'Searching Docker images...'
-            : debouncedQuery
-            ? `Results for "${debouncedQuery}"`
-            : 'Browse available services and add them to your compose.'}
-        </p>
+        <p className="text-gray-300 mt-1">{headerText}</p>
       </header>
 
       <div className="mb-6 grid grid-cols-1 gap-3 md:grid-cols-3">
         <div className="md:col-span-2">
           <div className="relative">
             <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
-              {/* simple search icon */}
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="opacity-80">
-                <path d="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z" stroke="currentColor" strokeWidth="2" />
-                <path d="M21 21l-4.3-4.3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                <path d="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z" stroke="currentColor" strokeWidth="2"/>
+                <path d="M21 21l-4.3-4.3" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
               </svg>
             </span>
             <input
@@ -148,35 +162,121 @@ const Catalog = () => {
 
       <section className="grid items-stretch gap-5 sm:gap-5 lg:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
         {loading
-          ? Array.from({ length: 8 }).map((_, i) => <SkeletonCard key={i} />)
+          ? Array.from({ length: 8 }).map((_, i) => (
+              <div key={i} className="h-full rounded-xl border border-gray-700 bg-gray-800 p-4 animate-pulse flex flex-col">
+                <div className="flex items-start gap-3">
+                  <div className="h-10 w-10 rounded-md bg-gray-700" />
+                  <div className="flex-1 space-y-2">
+                    <div className="h-4 w-1/3 bg-gray-700 rounded" />
+                    <div className="h-3 w-3/4 bg-gray-700 rounded" />
+                  </div>
+                </div>
+                <div className="mt-4 flex gap-3">
+                  <div className="h-3 w-16 bg-gray-700 rounded" />
+                  <div className="h-3 w-16 bg-gray-700 rounded" />
+                  <div className="h-3 w-24 bg-gray-700 rounded" />
+                </div>
+                <div className="mt-auto pt-4 h-9 w-full bg-gray-700 rounded" />
+              </div>
+            ))
           : filtered.map((img) => {
               const key = `${img.name}:${img.latestTag}`;
+              const added = !!addedMap[key];
+              const displayName = toTitleCase(img.name);
+              const imgUrl = (img as any).logo || (img as any).imageUrl || placeholderLogo;
+
               return (
-                <ServiceCard
+                <article
                   key={img.id}
-                  name={img.name}
-                  description={img.description}
-                  stars={img.stars}
-                  pulls={img.pulls}
-                  latestTag={img.latestTag}
-                  official={img.official}
-                  verified={img.verified}
-                  logo={img.logo}
-                  added={!!addedMap[key]}
-                  onAdd={() => onAdd(img)}
-                />
+                  className="catalogue-card group h-full rounded-xl border border-gray-700 bg-gray-800/80 hover:bg-gray-800 transition-colors shadow-sm p-4 flex flex-col"
+                >
+                  <div className="flex items-start gap-3">
+                    <img
+                      src={imgUrl}
+                      alt={displayName}
+                      className="catalogue-card-logo"
+                      loading="lazy"
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-start gap-2">
+                        <h3 className="service-title text-base md:text-lg font-semibold text-white">
+                          {displayName}
+                        </h3>
+                        <div className="ml-auto flex items-center gap-1 shrink-0">
+                          {img.latestTag && (
+                            <span className="text-xs text-gray-300 bg-gray-700 rounded px-2 py-0.5">
+                              {img.latestTag}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <p className="catalogue-desc mt-1 text-sm text-gray-300">
+                        {img.description}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="catalogue-card-footer mt-auto pt-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="catalogue-stats flex items-center gap-4 text-sm text-gray-300">
+                        <div className="flex items-center gap-1">
+                          <span aria-hidden className="text-yellow-400">★</span>
+                          <span>
+                            {img.stars >= 1_000_000_000
+                              ? (img.stars / 1_000_000_000).toFixed(1) + 'B'
+                              : img.stars >= 1_000_000
+                              ? (img.stars / 1_000_000).toFixed(1) + 'M'
+                              : img.stars >= 1_000
+                              ? (img.stars / 1_000).toFixed(1) + 'K'
+                              : String(img.stars)}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <span aria-hidden className="text-blue-400">⬇</span>
+                          <span>
+                            {img.pulls >= 1_000_000_000
+                              ? (img.pulls / 1_000_000_000).toFixed(1) + 'B'
+                              : img.pulls >= 1_000_000
+                              ? (img.pulls / 1_000_000).toFixed(1) + 'M'
+                              : img.pulls >= 1_000
+                              ? (img.pulls / 1_000).toFixed(1) + 'K'
+                              : String(img.pulls)}
+                          </span>
+                        </div>
+                      </div>
+
+                      <div className="flex items-center gap-2">
+                        {added ? (
+                          <button
+                            onClick={() => onRemove(img)}
+                            className="rounded-lg px-3 py-2 text-sm font-medium bg-red-600 hover:bg-red-500 text-white"
+                            aria-label={`Remove ${displayName}`}
+                            title="Remove from Composer"
+                          >
+                            Remove
+                          </button>
+                        ) : (
+                          <button
+                            onClick={() => onAdd(img)}
+                            className="catalogue-btn-add bg-blue-600 hover:bg-blue-500 text-white shrink-0 font-medium"
+                            aria-label={`Add ${displayName}`}
+                            title="Add to Composer"
+                          >
+                            Add to Composer
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </article>
               );
             })}
       </section>
 
-      <div className="mt-8 flex items-center justify-end gap-3">
-        <a
-          href="/composer"
-          className="rounded-lg px-4 py-2 text-sm font-medium bg-gray-700 hover:bg-gray-600 text-white"
-        >
-          Open Composer
-        </a>
-      </div>
+      {/* Fixed CTA in bottom-right */}
+      <a href="/composer" className="catalogue-composer-fab" aria-label="Open Composer">
+        Open Composer
+      </a>
     </div>
   );
 };

--- a/frontend/src/pages/Catalog.tsx
+++ b/frontend/src/pages/Catalog.tsx
@@ -1,8 +1,182 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { mockDockerImages, mockCategories, searchImages, type DockerImage } from '../mockdata';
+import ServiceCard from '../components/ServiceCard';
+import SkeletonCard from '../components/SkeletonCard';
+import { useDebouncedValue } from '../hooks/useDebouncedValue';
+
+type SelectedService = { name: string; tag: string };
+const STORAGE_KEY = 'composer:selectedServices';
+
+function loadSelections(): SelectedService[] {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+  } catch {
+    return [];
+  }
+}
+
+function saveSelections(items: SelectedService[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+}
+
 const Catalog = () => {
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState<string>('All');
+  const [loading, setLoading] = useState(false);
+  const [addedMap, setAddedMap] = useState<Record<string, boolean>>({});
+  const debouncedQuery = useDebouncedValue(query, 350);
+
+  // initialize added state from localStorage
+  useEffect(() => {
+    const saved = loadSelections();
+    const map: Record<string, boolean> = {};
+    saved.forEach((s) => (map[`${s.name}:${s.tag}`] = true));
+    setAddedMap(map);
+  }, []);
+
+  // compute filtered results from mock data
+  const filtered: DockerImage[] = useMemo(() => {
+    let list = mockDockerImages.slice();
+    if (category !== 'All') {
+      list = list.filter((i) => i.category === category);
+    }
+    if (debouncedQuery.trim()) {
+      const lower = debouncedQuery.toLowerCase();
+      // use helper search and then apply category
+      const searched = searchImages(debouncedQuery);
+      list = searched.filter((i) => (category === 'All' ? true : i.category === category));
+      // ensure deterministic order if helper expands later
+      list = list.filter(Boolean);
+      // Fallback simple filter to include more matches
+      if (list.length === 0) {
+        list = mockDockerImages.filter(
+          (i) =>
+            (category === 'All' ? true : i.category === category) &&
+            (i.name.toLowerCase().includes(lower) || i.description.toLowerCase().includes(lower))
+        );
+      }
+    }
+    // sort by popularity (stars desc, pulls desc)
+    list.sort((a, b) => b.stars - a.stars || b.pulls - a.pulls || a.name.localeCompare(b.name));
+    return list;
+  }, [category, debouncedQuery]);
+
+  // simulate loading state on every query/category change for skeleton UX
+  useEffect(() => {
+    setLoading(true);
+    const t = setTimeout(() => setLoading(false), 300);
+    return () => clearTimeout(t);
+  }, [debouncedQuery, category]);
+
+  const onAdd = (img: DockerImage) => {
+    const entry: SelectedService = { name: img.name, tag: img.latestTag };
+    const existing = loadSelections();
+    const key = `${entry.name}:${entry.tag}`;
+    if (!existing.some((e) => e.name === entry.name && e.tag === entry.tag)) {
+      const next = [...existing, entry];
+      saveSelections(next);
+      setAddedMap((prev) => ({ ...prev, [key]: true }));
+      // Notify other parts of the app (Composer) if listening
+      window.dispatchEvent(new CustomEvent('composer:addService', { detail: entry }));
+    }
+  };
+
   return (
-    <div className="max-w-7xl mx-auto p-8">
-      <h1 className="text-3xl font-bold mb-4">Catalog</h1>
-      <p className="text-gray-300">Browse available services, templates, and components.</p>
+    <div className="max-w-7xl mx-auto px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-3xl font-bold text-white">Catalog</h1>
+        <p className="text-gray-300 mt-1">
+          {loading
+            ? 'Searching Docker images...'
+            : debouncedQuery
+            ? `Results for "${debouncedQuery}"`
+            : 'Browse available services and add them to your compose.'}
+        </p>
+      </header>
+
+      <div className="mb-6 grid grid-cols-1 gap-3 md:grid-cols-3">
+        <div className="md:col-span-2">
+          <div className="relative">
+            <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+              {/* simple search icon */}
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="opacity-80">
+                <path d="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16Z" stroke="currentColor" strokeWidth="2" />
+                <path d="M21 21l-4.3-4.3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+              </svg>
+            </span>
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search images (e.g. nginx, postgres, redis)"
+              className="w-full rounded-xl bg-gray-800 border border-gray-700 text-gray-100 placeholder-gray-400 pl-10 pr-9 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="Search Docker images"
+            />
+            {query && (
+              <button
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-300 hover:text-white"
+                onClick={() => setQuery('')}
+                aria-label="Clear search"
+                title="Clear"
+              >
+                ×
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <div className="flex gap-2 flex-wrap">
+            {mockCategories.map((cat) => (
+              <button
+                key={cat}
+                onClick={() => setCategory(cat)}
+                className={`whitespace-nowrap rounded-full px-3 py-2 text-sm border transition
+                  ${
+                    category === cat
+                      ? 'bg-blue-600 border-blue-500 text-white'
+                      : 'bg-gray-800 border-gray-700 text-gray-200 hover:bg-gray-700'
+                  }`}
+                aria-pressed={category === cat}
+              >
+                {cat}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <section className="grid items-stretch gap-5 sm:gap-5 lg:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5">
+        {loading
+          ? Array.from({ length: 8 }).map((_, i) => <SkeletonCard key={i} />)
+          : filtered.map((img) => {
+              const key = `${img.name}:${img.latestTag}`;
+              return (
+                <ServiceCard
+                  key={img.id}
+                  name={img.name}
+                  description={img.description}
+                  stars={img.stars}
+                  pulls={img.pulls}
+                  latestTag={img.latestTag}
+                  official={img.official}
+                  verified={img.verified}
+                  logo={img.logo}
+                  added={!!addedMap[key]}
+                  onAdd={() => onAdd(img)}
+                />
+              );
+            })}
+      </section>
+
+      <div className="mt-8 flex items-center justify-end gap-3">
+        <a
+          href="/composer"
+          className="rounded-lg px-4 py-2 text-sm font-medium bg-gray-700 hover:bg-gray-600 text-white"
+        >
+          Open Composer
+        </a>
+      </div>
     </div>
   );
 };

--- a/frontend/src/styles/catalogue.css
+++ b/frontend/src/styles/catalogue.css
@@ -1,0 +1,119 @@
+/* Catalogue page styles */
+
+.catalogue-page {
+  /* Allow long words/URLs to wrap naturally */
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
+/* Fully visible titles (no truncation) */
+.catalogue-page h3,
+.catalogue-page .service-title {
+  white-space: normal !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+  line-height: 1.25;
+  min-width: 0;
+  word-break: break-word;
+}
+
+/* Equal-height cards and stable footer at bottom */
+.catalogue-page .catalogue-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  box-sizing: border-box;
+  overflow: hidden; /* prevent child overflow */
+}
+
+.catalogue-page .catalogue-card * {
+  min-width: 0; /* allow flex children to shrink and ellipsize */
+}
+
+.catalogue-page .catalogue-card-footer {
+  margin-top: auto;
+}
+
+/* Description clamps to avoid overflow while keeping heights consistent */
+.catalogue-page .catalogue-desc {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;      /* show up to 3 lines */
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Consistent logo sizing (from mockdata URL) */
+.catalogue-page .catalogue-card-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 0.375rem;
+  object-fit: contain;
+  background: #374151; /* gray-700 */
+  padding: 4px;
+}
+
+/* Keep stars and downloads on one line */
+.catalogue-page .catalogue-stats {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  white-space: nowrap; /* prevent wrapping */
+}
+
+/* Fixed "Open Composer" FAB bottom-right */
+.catalogue-composer-fab {
+  position: fixed;
+  right: max(1rem, env(safe-area-inset-right));
+  bottom: max(1rem, env(safe-area-inset-bottom));
+  z-index: 50;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+
+  color: #ffffff;
+  background: #2563eb; /* blue-600 */
+  box-shadow:
+    0 10px 15px -3px rgba(0, 0, 0, 0.3),
+    0 4px 6px -2px rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+
+  transition: background-color 0.2s ease, transform 0.2s ease;
+  text-decoration: none;
+}
+
+.catalogue-composer-fab:hover {
+  background: #3b82f6; /* blue-500 */
+}
+
+.catalogue-composer-fab:active {
+  transform: translateY(1px);
+  box-shadow:
+    0 4px 6px -2px rgba(0, 0, 0, 0.2),
+    0 2px 4px -1px rgba(0, 0, 0, 0.3);
+}
+
+/* Small screens */
+@media (max-width: 640px) {
+  .catalogue-composer-fab {
+    padding: 0.6rem 0.85rem;
+    font-size: 0.9rem;
+    right: max(0.75rem, env(safe-area-inset-right));
+    bottom: max(0.75rem, env(safe-area-inset-bottom));
+    border-radius: 0.65rem;
+  }
+}
+
+/* Small “Add to Composer” button */
+.catalogue-btn-add {
+  padding: 0.375rem 0.625rem;   /* ~py-1.5 px-2.5 */
+  font-size: 0.75rem;           /* text-xs */
+  line-height: 1rem;
+  border-radius: 0.375rem;      /* rounded-md */
+  white-space: nowrap;          /* keep label on one line */
+}


### PR DESCRIPTION

## Description

- Implement Service Catalog page styled similar to ComposeGenie Catalog.
- Uses frontend/src/mockdata.ts for images and categories.
- Debounced search bar, category filter chips.
- Responsive grid with equal-height cards and bottom-aligned actions.
- Skeleton loaders during search/filter transitions.
- “Add to Composer” persists to localStorage (composer:selectedServices) and dispatches composer:addService event.
- Minor accessibility and UI polish (icons, truncation, spacing).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issue

Fixes #3 

## Testing

- [x] I have tested these changes locally
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked that the code builds successfully

## Screenshots/Video Recording (if applicable)

<img width="1892" height="966" alt="Screenshot 2025-10-14 211444" src="https://github.com/user-attachments/assets/258caddc-0510-47f3-be48-c5c3008deebd" />

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

Have a look @Sanjeev-Kumar78 


